### PR TITLE
Fix CreateBackupJob.php  to work with laravel-backup v9

### DIFF
--- a/src/Jobs/CreateBackupJob.php
+++ b/src/Jobs/CreateBackupJob.php
@@ -7,6 +7,8 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Spatie\Backup\Tasks\Backup\BackupJobFactory;
+use Spatie\Backup\Config\Config as BackupConfig;
+
 
 class CreateBackupJob implements ShouldQueue
 {
@@ -21,8 +23,8 @@ class CreateBackupJob implements ShouldQueue
 
     public function handle()
     {
-        $backupJob = BackupJobFactory::createFromArray(config('backup'));
-
+        $backupJob = BackupJobFactory::createFromConfig(BackupConfig::fromArray(config('backup')));
+        
         if ($this->option === 'only-db') {
             $backupJob->dontBackupFilesystem();
         }


### PR DESCRIPTION
Hi,

This patch fix incompatibility with laravel-backup v9
In laravel-backup v9, they have removed   BackupJobFactory::createFromArray method  so the queued job fails

Regards